### PR TITLE
fix: format visit times nicely

### DIFF
--- a/client/src/app/users/[userId]/page.tsx
+++ b/client/src/app/users/[userId]/page.tsx
@@ -24,7 +24,7 @@ const UserSummaryVisitCard = ({ visit }: UserSummaryVisitCardProps) => {
       </Link>
       {visitDate && (
         <div className="">
-          {visitDate.toLocaleDateString()}
+          {visitDate.toLocaleDateString()}{" "}
           {visitDate.toLocaleTimeString("en-UK", {
             hour: "2-digit",
             minute: "2-digit",


### PR DESCRIPTION
Add space in between date and time on `/user/[userId]` visits cards