### PR TITLE
feat: only show notes and drink when they have content

### DIFF
--- a/client/src/app/users/[userId]/page.tsx
+++ b/client/src/app/users/[userId]/page.tsx
@@ -32,10 +32,14 @@ const UserSummaryVisitCard = ({ visit }: UserSummaryVisitCardProps) => {
           })}
         </div>
       )}
-      <div>
-        <span className="font-bold">Drink:</span> {visit.drink}
-      </div>
-      <div>&apos;{visit.notes}&apos;</div>
+      {visit.drink && visit.drink !== "" && (
+        <div>
+          <span className="font-bold">Drink:</span> {visit.drink}
+        </div>
+      )}
+      {visit.notes && visit.notes !== "" && (
+        <div>&apos;{visit.notes}&apos;</div>
+      )}
       <Rating style={{ maxWidth: 100 }} value={visit.rating ?? 0} readOnly />
     </div>
   )

--- a/client/src/app/venues/[venueId]/page.tsx
+++ b/client/src/app/venues/[venueId]/page.tsx
@@ -132,11 +132,15 @@ const VenueVisitCard = ({ visit }: VenueVisitProps) => {
           })}
         </div>
       )}
-      <div>
-        <span className="font-bold">Drink: </span>
-        {visit.drink}
-      </div>
-      <div>&apos;{visit.notes}&apos;</div>
+      {visit.drink && visit.drink !== "" && (
+        <div>
+          <span className="font-bold">Drink: </span>
+          {visit.drink}
+        </div>
+      )}
+      {visit.notes && visit.notes !== "" && (
+        <div>&apos;{visit.notes}&apos;</div>
+      )}
       <Rating
         style={{ maxWidth: 100 }}
         value={visit.rating ?? 0}


### PR DESCRIPTION
When the notes and/or drink for a visit are not present (or empty), don't display them on the venue list of visits, or the user list of visits